### PR TITLE
Use etcher-electron.sh as Etcher's entry point

### DIFF
--- a/etcher/files/etcher-electron.sh
+++ b/etcher/files/etcher-electron.sh
@@ -3,4 +3,4 @@
 cd /usr/share/etcher/
 ./etcher
 export ETCHER_DISABLE_UPDATES=1
-/usr/lib/etcher-electron/etcher "$@"
+/usr/share/etcher/etcher "$@"

--- a/etcher/package.yml
+++ b/etcher/package.yml
@@ -38,7 +38,7 @@ install    : |
     #move etcher-electron.sh to /usr/share folder. File disables automatic updates for GUI. 
     install -Dm 00644 $pkgfiles/etcher-electron.sh $installdir/usr/share/etcher/etcher-electron.sh
 
-    ln -s /usr/share/etcher/etcher $installdir/usr/bin/
+    ln -s /usr/share/etcher/etcher-electron.sh $installdir/usr/bin/etcher
     
 
     #Desktop File


### PR DESCRIPTION
- Edit `etcher-electron.sh` to point to the real `etcher` binary
- Symlink `etcher-electron.sh` to /usr/bin/etcher

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>